### PR TITLE
PCT-1161 Agent report crashing

### DIFF
--- a/log/slow/parser.go
+++ b/log/slow/parser.go
@@ -1,5 +1,5 @@
 /*
-	Copyright (c) 2014, Percona LLC and/or its affiliates. All rights reserved.
+	Copyright (c) 2014-2015, Percona LLC and/or its affiliates. All rights reserved.
 
 	This program is free software: you can redistribute it and/or modify
 	it under the terms of the GNU Affero General Public License as published by

--- a/log/slow/parser.go
+++ b/log/slow/parser.go
@@ -197,6 +197,9 @@ func (p *SlowLogParser) parseHeader(line string) {
 			l.Println("time")
 		}
 		m := timeRe.FindStringSubmatch(line)
+		if len(m) < 2 {
+			return
+		}
 		p.event.Ts = m[1]
 		if userRe.MatchString(line) {
 			if p.opt.Debug {
@@ -211,6 +214,9 @@ func (p *SlowLogParser) parseHeader(line string) {
 			l.Println("user")
 		}
 		m := userRe.FindStringSubmatch(line)
+		if len(m) < 3 {
+			return
+		}
 		p.event.User = m[1]
 		p.event.Host = m[2]
 	} else if strings.HasPrefix(line, "# admin") {

--- a/log/slow/parser_test.go
+++ b/log/slow/parser_test.go
@@ -1713,7 +1713,8 @@ func (s *TestSuite) TestParseSlow023(t *C) {
 		t.Error(diff)
 	}
 }
-func (s *TestSuite) TestParseSlow024(t *C) {
+
+func (s *TestSuite) TestParseSlow023A(t *C) {
 	filename := "slow023.log"
 	o := log.Options{Debug: false}
 
@@ -1733,5 +1734,78 @@ func (s *TestSuite) TestParseSlow024(t *C) {
 		} else {
 			lastQuery = e.Query
 		}
+	}
+}
+
+/*
+   Test header with invalid # Time or invalid # User lines
+*/
+func (s *TestSuite) TestParseSlow024(t *C) {
+	got := s.parseSlowLog("slow024.log", log.Options{Debug: false})
+	expect := []log.Event{
+		{
+			Offset: 200,
+			Ts:     "071015 21:43:52",
+			Admin:  false,
+			Query:  "select sleep(1) from n",
+			User:   "root",
+			Host:   "localhost",
+			Db:     "test",
+			TimeMetrics: map[string]float32{
+				"Lock_time":  0,
+				"Query_time": 2,
+			},
+			NumberMetrics: map[string]uint64{
+				"Rows_examined": 0,
+				"Rows_sent":     1,
+			},
+			BoolMetrics: map[string]bool{},
+			RateType:    "",
+			RateLimit:   0,
+		},
+		{
+			Offset: 362,
+			Ts:     "",
+			Admin:  false,
+			Query:  "select sleep(2) from n",
+			User:   "root",
+			Host:   "localhost",
+			Db:     "test",
+			TimeMetrics: map[string]float32{
+				"Lock_time":  0,
+				"Query_time": 2,
+			},
+			NumberMetrics: map[string]uint64{
+				"Rows_examined": 0,
+				"Rows_sent":     1,
+			},
+			BoolMetrics: map[string]bool{},
+			RateType:    "",
+			RateLimit:   0,
+		},
+		{
+			Offset: 508,
+			Ts:     "071015 21:43:52",
+			Admin:  false,
+			Query:  "select sleep(3) from n",
+			User:   "",
+			Host:   "",
+			Db:     "test",
+			TimeMetrics: map[string]float32{
+				"Lock_time":  0,
+				"Query_time": 2,
+			},
+			NumberMetrics: map[string]uint64{
+				"Rows_examined": 0,
+				"Rows_sent":     1,
+			},
+			BoolMetrics: map[string]bool{},
+			RateType:    "",
+			RateLimit:   0,
+		},
+	}
+	if same, diff := IsDeeply(got, expect); !same {
+		Dump(got)
+		t.Error(diff)
 	}
 }

--- a/test/slow-logs/slow024.log
+++ b/test/slow-logs/slow024.log
@@ -1,0 +1,18 @@
+/usr/sbin/mysqld, Version: 5.0.38-Ubuntu_0ubuntu1.1-log (Ubuntu 7.04 distribution). started with:
+Tcp port: 3306  Unix socket: /var/run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+# Time: 071015 21:43:52 
+# User@Host: root[root] @ localhost []
+# Query_time: 2  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+use `test`;
+select sleep(1) from n;
+# Time: 
+# User@Host: root[root] @ localhost []
+# Query_time: 2  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+use `test`;
+select sleep(2) from n;
+# Time: 071015 21:43:52 
+# User@Host: 
+# Query_time: 2  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+use `test`;
+select sleep(3) from n;


### PR DESCRIPTION
- The slow log was failing when the slow log file had an invalid # Time or # User lines.