### PR TITLE
PCT-1216 Bug with sampling

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -55,6 +55,7 @@ type Options struct {
 	StartOffset        uint64          // byte offset in file at which to start parsing
 	FilterAdminCommand map[string]bool // admin commands to ignore
 	Debug              bool            // print trace info to STDOUT
+	MaxQueryTime       float32         // Ignore queries having Query_time > MaxQueryTime
 }
 
 // A LogParser sends events to a channel.

--- a/log/slow/parser.go
+++ b/log/slow/parser.go
@@ -44,17 +44,16 @@ type SlowLogParser struct {
 	file *os.File
 	opt  log.Options
 	// --
-	stopChan      chan bool
-	eventChan     chan *log.Event
-	inHeader      bool
-	inQuery       bool
-	headerLines   uint
-	queryLines    uint64
-	bytesRead     uint64
-	lineOffset    uint64
-	stopped       bool
-	event         *log.Event
-	lastQueryTime uint64
+	stopChan    chan bool
+	eventChan   chan *log.Event
+	inHeader    bool
+	inQuery     bool
+	headerLines uint
+	queryLines  uint64
+	bytesRead   uint64
+	lineOffset  uint64
+	stopped     bool
+	event       *log.Event
 }
 
 // NewSlowLogParser returns a new SlowLogParser that reads from the open file.

--- a/log/slow/parser_test.go
+++ b/log/slow/parser_test.go
@@ -1809,3 +1809,35 @@ func (s *TestSuite) TestParseSlow024(t *C) {
 		t.Error(diff)
 	}
 }
+
+// slow025 Test setting MaxQueryTime
+// The first query should be skipped because Query_time = 2 > MaxQueryTime = 1
+func (s *TestSuite) TestParserSlowLog025(t *C) {
+	opt := s.opt
+	opt.MaxQueryTime = 1
+	got := s.parseSlowLog("slow025.log", opt)
+	expect := []log.Event{
+		{
+			Ts:     "071015 21:45:10",
+			Admin:  false,
+			Query:  `select sleep(2) from test.n`,
+			User:   "root",
+			Host:   "localhost",
+			Db:     "sakila",
+			Offset: 359,
+			TimeMetrics: map[string]float32{
+				"Query_time": 1,
+				"Lock_time":  0,
+			},
+			NumberMetrics: map[string]uint64{
+				"Rows_sent":     1,
+				"Rows_examined": 0,
+			},
+			BoolMetrics: map[string]bool{},
+		},
+	}
+	if same, diff := IsDeeply(got, expect); !same {
+		Dump(got)
+		t.Error(diff)
+	}
+}

--- a/test/slow-logs/slow025.log
+++ b/test/slow-logs/slow025.log
@@ -1,0 +1,13 @@
+/usr/sbin/mysqld, Version: 5.0.38-Ubuntu_0ubuntu1.1-log (Ubuntu 7.04 distribution). started with:
+Tcp port: 3306  Unix socket: /var/run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+# Time: 071015 21:43:52
+# User@Host: root[root] @ localhost []
+# Query_time: 2  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+use test;
+select sleep(1) from n;
+# Time: 071015 21:45:10
+# User@Host: root[root] @ localhost []
+# Query_time: 1  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+use sakila;
+select sleep(2) from test.n;


### PR DESCRIPTION
Added a new parameter MaxQueryTime that is being read from @slow_query_log_always_write_time MySQL var.
All queries having Query_time > MaxQueryTime should be skiped because that query is in the log due to the time it took to run and not because of the sampling.