### PR TITLE
PCT-1216 Bug with sampling

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -55,6 +55,7 @@ type Options struct {
 	StartOffset        uint64          // byte offset in file at which to start parsing
 	FilterAdminCommand map[string]bool // admin commands to ignore
 	Debug              bool            // print trace info to STDOUT
+	MaxQueryTime       float32         // Ignore queries having Query_time > MaxQueryTime
 }
 
 // A LogParser sends events to a channel.

--- a/log/log.go
+++ b/log/log.go
@@ -55,7 +55,7 @@ type Options struct {
 	StartOffset        uint64          // byte offset in file at which to start parsing
 	FilterAdminCommand map[string]bool // admin commands to ignore
 	Debug              bool            // print trace info to STDOUT
-	MaxQueryTime       float32         // Ignore queries having Query_time > MaxQueryTime
+	RateMaxQueryTime   float32         // If Query_time > MaxQueryTime do not apply rate (do not multiply)
 }
 
 // A LogParser sends events to a channel.

--- a/log/slow/parser.go
+++ b/log/slow/parser.go
@@ -358,8 +358,10 @@ func (p *SlowLogParser) sendEvent(inHeader bool, inQuery bool) {
 		// Started parsing in header after Query_time.  Throw away event.
 		return
 	}
-	if p.opt.MaxQueryTime > 0 && p.event.TimeMetrics["Query_time"] > p.opt.MaxQueryTime {
-		return // Ignore the event if it took more than MaxQueryTime
+	// If the query was logged because it took more than RateMaxQueryTime
+	// the rate should be ignored to prevent a wrong sampling
+	if p.opt.RateMaxQueryTime > 0 && p.event.TimeMetrics["Query_time"] > p.opt.RateMaxQueryTime {
+		p.event.RateLimit = 0
 	}
 	// Clean up the event.
 	p.event.Db = strings.TrimSuffix(p.event.Db, ";\n")

--- a/log/slow/parser.go
+++ b/log/slow/parser.go
@@ -21,13 +21,14 @@ package slow
 import (
 	"bufio"
 	"fmt"
-	"github.com/percona/go-mysql/log"
 	"io"
 	l "log"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/percona/go-mysql/log"
 )
 
 // Regular expressions to match important lines in slow log.
@@ -360,6 +361,11 @@ func (p *SlowLogParser) sendEvent(inHeader bool, inQuery bool) {
 	}
 	// If the query was logged because it took more than RateMaxQueryTime
 	// the rate should be ignored to prevent a wrong sampling
+	// I.e. one query took 5 minutes with sampling 1/1000 we shuld not count
+	// it as 1000 of 5min queries.
+	// This depends on the value of slow_query_log_always_write_time so it
+	// affects only to Percona Server 5.6.13+
+	// http://www.percona.com/doc/percona-server/5.6/diagnostics/slow_extended.html#slow_query_log_always_write_time
 	if p.opt.RateMaxQueryTime > 0 && p.event.TimeMetrics["Query_time"] > p.opt.RateMaxQueryTime {
 		p.event.RateLimit = 0
 	}

--- a/log/slow/parser.go
+++ b/log/slow/parser.go
@@ -44,17 +44,16 @@ type SlowLogParser struct {
 	file *os.File
 	opt  log.Options
 	// --
-	stopChan      chan bool
-	eventChan     chan *log.Event
-	inHeader      bool
-	inQuery       bool
-	headerLines   uint
-	queryLines    uint64
-	bytesRead     uint64
-	lineOffset    uint64
-	stopped       bool
-	event         *log.Event
-	lastQueryTime uint64
+	stopChan    chan bool
+	eventChan   chan *log.Event
+	inHeader    bool
+	inQuery     bool
+	headerLines uint
+	queryLines  uint64
+	bytesRead   uint64
+	lineOffset  uint64
+	stopped     bool
+	event       *log.Event
 }
 
 // NewSlowLogParser returns a new SlowLogParser that reads from the open file.

--- a/log/slow/parser_test.go
+++ b/log/slow/parser_test.go
@@ -1810,21 +1810,44 @@ func (s *TestSuite) TestParseSlow024(t *C) {
 	}
 }
 
-// slow025 Test setting MaxQueryTime
-// The first query should be skipped because Query_time = 2 > MaxQueryTime = 1
+// slow025 Test setting RateMaxQueryTime
 func (s *TestSuite) TestParserSlowLog025(t *C) {
 	opt := s.opt
-	opt.MaxQueryTime = 1
+	opt.RateMaxQueryTime = 1
 	got := s.parseSlowLog("slow025.log", opt)
 	expect := []log.Event{
 		{
-			Ts:     "071015 21:45:10",
-			Admin:  false,
-			Query:  `select sleep(2) from test.n`,
-			User:   "root",
-			Host:   "localhost",
-			Db:     "sakila",
-			Offset: 359,
+			Ts:       "071015 21:43:52",
+			Admin:    false,
+			Query:    `select sleep(1) from n`,
+			User:     "root",
+			Host:     "localhost",
+			Db:       "test",
+			Offset:   200,
+			RateType: "query",
+			// In slow025.log, RateLimit = 2 but the parser must
+			// return 0 because Query_time > RateMaxQueryTime
+			RateLimit: 0,
+			TimeMetrics: map[string]float32{
+				"Query_time": 2,
+				"Lock_time":  0,
+			},
+			NumberMetrics: map[string]uint64{
+				"Rows_sent":     1,
+				"Rows_examined": 0,
+			},
+			BoolMetrics: map[string]bool{},
+		},
+		{
+			Ts:        "071015 21:45:10",
+			Admin:     false,
+			Query:     `select sleep(2) from test.n`,
+			User:      "root",
+			Host:      "localhost",
+			Db:        "sakila",
+			Offset:    411,
+			RateType:  "query",
+			RateLimit: 2,
 			TimeMetrics: map[string]float32{
 				"Query_time": 1,
 				"Lock_time":  0,

--- a/log/slow/parser_test.go
+++ b/log/slow/parser_test.go
@@ -1809,3 +1809,35 @@ func (s *TestSuite) TestParseSlow024(t *C) {
 		t.Error(diff)
 	}
 }
+
+// slow025 Test setting MaxQueryTime
+// The first query should be skipped because Query_time = 2 > MaxQueryTime = 1
+func (s *TestSuite) TestParserSlowLog025(t *C) {
+	opt := s.opt
+	opt.MaxQueryTime = 1
+	got := s.parseSlowLog("slow025.log", opt)
+	expect := []log.Event{
+		{
+			Ts:     "071015 21:45:10",
+			Admin:  false,
+			Query:  `select sleep(2) from test.n`,
+			User:   "root",
+			Host:   "localhost",
+			Db:     "sakila",
+			Offset: 359,
+			TimeMetrics: map[string]float32{
+				"Query_time": 1,
+				"Lock_time":  0,
+			},
+			NumberMetrics: map[string]uint64{
+				"Rows_sent":     1,
+				"Rows_examined": 0,
+			},
+			BoolMetrics: map[string]bool{},
+		},
+	}
+	if same, diff := IsDeeply(got, expect); !same {
+		Dump(got)
+		t.Error(diff)
+	}
+}

--- a/test/slow-logs/slow025.log
+++ b/test/slow-logs/slow025.log
@@ -1,0 +1,13 @@
+/usr/sbin/mysqld, Version: 5.0.38-Ubuntu_0ubuntu1.1-log (Ubuntu 7.04 distribution). started with:
+Tcp port: 3306  Unix socket: /var/run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+# Time: 071015 21:43:52
+# User@Host: root[root] @ localhost []
+# Query_time: 2  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+use test;
+select sleep(1) from n;
+# Time: 071015 21:45:10
+# User@Host: root[root] @ localhost []
+# Query_time: 1  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+use sakila;
+select sleep(2) from test.n;

--- a/test/slow-logs/slow025.log
+++ b/test/slow-logs/slow025.log
@@ -4,10 +4,12 @@ Time                 Id Command    Argument
 # Time: 071015 21:43:52
 # User@Host: root[root] @ localhost []
 # Query_time: 2  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+# Log_slow_rate_type: query  Log_slow_rate_limit: 2
 use test;
 select sleep(1) from n;
 # Time: 071015 21:45:10
 # User@Host: root[root] @ localhost []
 # Query_time: 1  Lock_time: 0  Rows_sent: 1  Rows_examined: 0
+# Log_slow_rate_type: query  Log_slow_rate_limit: 2
 use sakila;
 select sleep(2) from test.n;


### PR DESCRIPTION
I have misunderstood the solution in my previous commit.
If a query took more than RateMaxQueryTime it shouldn't be ignored, we need to force RateLimit = 0/1 (internally if we are convering Rates=0 to 1) to avoid an error with the sampling.
