### PR TITLE
add buf init size in case of slice out of range memory

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -138,7 +138,7 @@ var ReplaceNumbersInWords = false
 func Fingerprint(q string) string {
 	q += " " // need range to run off end of original query
 	prevWord := ""
-	f := make([]byte, len(q))
+	f := make([]byte, len(q)+8)
 	fi := 0
 	pr := rune(0) // previous rune
 	s := unknown  // current state

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -239,6 +239,13 @@ func (s *TestSuite) TestFingerprintBasic(t *C) {
 		Equals,
 		"select * from prices.rt_5min where id=?",
 	)
+	// Fingerprint Insert into tables;
+	q = "insert into t3 values(2);"
+	t.Check(
+		query.Fingerprint(q),
+		Equals,
+		"insert into t3 values(?+);",
+	)
 
 	// Fingerprint /* -- comment */ SELECT (bug 1174956)
 	q = "/* -- S++ SU ABORTABLE -- spd_user: rspadim */SELECT SQL_SMALL_RESULT SQL_CACHE DISTINCT centro_atividade FROM est_dia WHERE unidade_id=1001 AND item_id=67 AND item_id_red=573"


### PR DESCRIPTION
- "insert into t3 values(2);"  will result in index out of range 
add init buf size to fix 