### PR TITLE
PMM-481 Fixed tricky fingerprint

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -388,10 +388,11 @@ func Fingerprint(q string) string {
 			if pr == '*' && r == '/' {
 				// /* foo */ -> (nothing)
 				if Debug {
-					fmt.Println("Multi-line comment end")
+					fmt.Printf("Multi-line comment end. pr: %s\n", string(pr))
 				}
 				s = unknown
 			} else {
+				pr = r
 				if Debug {
 					fmt.Println("Ignore multi-line comment content")
 				}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -454,6 +454,20 @@ func (s *TestSuite) TestFingerprintTricky(t *C) {
 		Equals,
 		"insert into t () values()",
 	)
+
+	q = "SELECT * FROM table WHERE field = 'value' /*arbitrary/31*/ "
+	t.Check(
+		query.Fingerprint(q),
+		Equals,
+		"select * from table where field = ?",
+	)
+
+	q = "SELECT * FROM table WHERE field = 'value' /*arbitrary31*/ "
+	t.Check(
+		query.Fingerprint(q),
+		Equals,
+		"select * from table where field = ?",
+	)
 }
 
 func (s *TestSuite) TestNumbersInFunctions(t *C) {


### PR DESCRIPTION
While in multi-line comments, we were not storing the last character found so, the last char in the pr var was an `*`, found at the beginning of the comment. For that reason, when we found a `/` inside the comment like:
`/* SELECT BLA BLA BLA ; /* this is for url /home/index */`
the `/` between `home` and `index` was detected as the comment end.
