### PR TITLE
PMM-2643: Another parsing fix.

### DIFF
--- a/dsn/dsn.go
+++ b/dsn/dsn.go
@@ -365,6 +365,7 @@ func parseLsofForSockets(output []byte) (sockets []string) {
 		// lsof on trusty:                 `/var/run/mysqld/mysqld.sock`
 		// lsof on xenial, artful, bionic: `/var/run/mysqld/mysqld.sock type=STREAM`
 		line = bytes.TrimSuffix(line, []byte("type=STREAM"))
+		line = bytes.TrimSuffix(line, []byte("type=DGRAM"))
 		line = bytes.TrimSpace(line)
 
 		// Skip empty lines.


### PR DESCRIPTION
@Nailya had a case on xenial where `lsof` returned `ntype=DGRAM` and `ntype=STREAM` without any path.
I'm not sure what are those but we can try to avoid this by checking for absolute path.
```
# lsof -a -n -P -U -F n -p $(pgrep -x mysqld | tr \\n ,)
p952
f3
ntype=DGRAM
f18
ntype=STREAM
f19
ntype=STREAM
f22
n/var/run/mysqld/mysqld.sock type=STREAM
f24
n/var/run/mysqld/mysqlx.sock type=STREAM
```