### PR TITLE
fix fi overflow panic because of multi 'in values' in query text

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -379,6 +379,9 @@ func Fingerprint(q string) string {
 			valueNo++
 			if valueNo == 1 {
 				if qi-firstPar > 1 {
+					if qi-firstPar == 2 {
+						f = append(f, 0)
+					}
 					copy(f[fi:fi+4], "(?+)")
 					fi += 4
 				} else {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -556,6 +556,13 @@ func TestFingerprintPanicChallenge2(t *testing.T) {
 		query.Fingerprint(q),
 	)
 
+	q = "select col1 from tb1 where cond1 in(1) and cond2 in(2)"
+	assert.Equal(
+		t,
+		"select col1 from tb1 where cond1 in(?+) and cond2 in(?+)",
+		query.Fingerprint(q),
+	)
+
 	q = "delete from db.table where col1 in(1) and col2=1"
 	assert.Equal(
 		t,


### PR DESCRIPTION
the real reason that  fi overflow cause index out of range panic is the length of variable f slice need increament when in values length in quota is less than 2

sql: select col1 from tb1 where cond1 in(1) and cond2 in(2);
Fingerprint(sql) got panic: index out of range
![image](https://user-images.githubusercontent.com/11739090/121012194-0f5ce700-c7ca-11eb-8354-5c2d0cdb98ac.png)

after fix
![image](https://user-images.githubusercontent.com/11739090/121012286-269bd480-c7ca-11eb-9e68-6a0744e975a4.png)
