### PR TITLE
Fix slow log parsing with tab bug

### DIFF
--- a/log/slow/parser.go
+++ b/log/slow/parser.go
@@ -41,6 +41,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/percona/go-mysql/log"
 )
@@ -168,7 +169,7 @@ SCANNER_LOOP:
 		//   Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
 		//   Time                 Id Command    Argument
 		if lineLen >= 20 && ((line[0] == '/' && line[lineLen-6:lineLen] == "with:\n") ||
-			(line[0:5] == "Time ") ||
+			(line[0:4] == "Time" && unicode.IsSpace(rune(line[5]))) ||
 			(line[0:4] == "Tcp ") ||
 			(line[0:4] == "TCP ")) {
 			if p.opt.Debug {

--- a/log/slow/parser_test.go
+++ b/log/slow/parser_test.go
@@ -1888,6 +1888,39 @@ func TestParseSlowMariaDBWithExplain(t *testing.T) {
 	assert.EqualValues(t, expect, got)
 }
 
+func TestParseSlowMariaDBWithTab(t *testing.T) {
+	got := parseSlowLog("mariadb108-with-tab.log", opt)
+	expect := []log.Event{
+		{
+			Offset:    161,
+			OffsetEnd: 590,
+			Ts:        time.Date(2022, 8, 13, 12, 04, 19, 0, time.UTC),
+			Admin:     false,
+			Query:     "select sleep(15), @@version",
+			User:      "root",
+			Host:      "localhost",
+			Db:        "",
+			TimeMetrics: map[string]float64{
+				"Lock_time":  0,
+				"Query_time": 15.000337,
+			},
+			NumberMetrics: map[string]uint64{
+				"Bytes_sent":    117,
+				"Rows_affected": 0,
+				"Rows_examined": 0,
+				"Rows_sent":     1,
+				"Thread_id":     4,
+			},
+			BoolMetrics: map[string]bool{
+				"QC_hit": false,
+			},
+			RateType:  "",
+			RateLimit: 0,
+		},
+	}
+	assert.EqualValues(t, expect, got)
+}
+
 func TestParseSlow026(t *testing.T) {
 	got := parseSlowLog("slow026.log", opt)
 	expect := []log.Event{

--- a/test/slow-logs/mariadb108-with-tab.log
+++ b/test/slow-logs/mariadb108-with-tab.log
@@ -1,0 +1,13 @@
+/usr/sbin/mariadbd, Version: 10.8.3-MariaDB (MariaDB Server). started with:
+Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
+Time		    Id Command	Argument
+# Time: 220813 12:04:19
+# User@Host: root[root] @ localhost []
+# Thread_id: 4  Schema:   QC_hit: No
+# Query_time: 15.000337  Lock_time: 0.000000  Rows_sent: 1  Rows_examined: 0
+# Rows_affected: 0  Bytes_sent: 117
+SET timestamp=1660392259;
+select sleep(15), @@version;
+/usr/sbin/mariadbd, Version: 10.8.3-MariaDB (MariaDB Server). started with:
+Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
+Time		    Id Command	Argument


### PR DESCRIPTION
With MariaDB **10.8.3**, the slow log format has been changed a little bit. It adds tab character behind the 'Time' column, which causes the slow log parsing failed.

Take this [test log file](https://github.com/percona/go-mysql/pull/60/files#diff-ee0b0c6bad67463b059967fc6db2c843b4f9ccfcc9da8f348eadf64b06088574R13) as example, there are 2 tab characters behind the 'Time' column.
![CleanShot 2022-08-13 at 21 24 09@2x](https://user-images.githubusercontent.com/61085039/184496135-e99a4b49-b5a7-4d0d-abf5-ee1029af70ee.png)


I think same thing happend to [PMM2.0](https://github.com/percona/go-mysql/blob/73d29c6da78c040492634b29a29831417e65a68c/log/slow/parser.go#L173), but I haven't get along with PMM2.0, so I just leave it to you guys.

cc @gordan-bobic