### PR TITLE
Fix missing head string in fingerprint of an unexpected CALL statement

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -687,7 +687,7 @@ func Fingerprint(q string) string {
 				if Debug {
 					fmt.Println("CALL sp_name")
 				}
-				return "call " + q[cpFromOffset:qi]
+				return string(f[0:fi]) + q[cpFromOffset:qi]
 			} else if sqlState != onDupeKeyUpdate && (((s == inSpace || s == moreValuesOrUnknown) && (prevWord == "value" || prevWord == "values" || prevWord == "in")) || wordIn(q[cpFromOffset:qi], "value", "values", "in")) {
 				// VALUE(, VALUE (, VALUES(, VALUES (, IN(, or IN(
 				// but not after ON DUPLICATE KEY UPDATE

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -663,3 +663,14 @@ func TestFingerprintWithNumberInDbName(t *testing.T) {
 		query.Fingerprint(q),
 	)
 }
+
+func TestFingerprintUnexpected(t *testing.T) {
+	var q string
+
+	q = "EXPLAIN CALL foo(1, 2, 3)"
+	assert.Equal(
+		t,
+		"explain call foo",
+		query.Fingerprint(q),
+	)
+}


### PR DESCRIPTION
When generating a fingerprint for an CALL statement with some extra string in the head, it will return a fingerprint of a normal CALL statement, for example, `EXPLAIN call test.testCall('test')` => `call test.testCall`, the extra string in the head is missing.

I understand EXPLAIN doesn't support CALL statement, if it only intends to generate fingerprint for vaild SQL, then it should return something else instead of a normal CALL fingerprint. If it intends to generate fingerprint for any SQL that could be logged in slow query log, then I think the patch in this pull request should be merged (or maybe someone has a better idea).

PS: It seems that [PMM-2.0](https://github.com/percona/go-mysql/blob/PMM-2.0/query/query.go#L690) has the same problem