### PR TITLE
Fix Fingerprint() to make it work correctly with MAX_EXECUTION_TIME statement

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -541,8 +541,8 @@ func Fingerprint(q string) string {
 					// so advance cpFromOffset to whatever is after the space
 					// and if it's more space then space skipping block will
 					// handle it.
-					cpFromOffset = qi + 1
 				}
+				cpFromOffset = qi + 1
 			} else if s == inDash {
 				if Debug {
 					fmt.Println("One-line comment begin")

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -650,3 +650,22 @@ func TestFingerprintWithNumberInDbName(t *testing.T) {
 		query.Fingerprint(q),
 	)
 }
+
+func TestFingerprintMaxExecTimeWithBackticks(t *testing.T) {
+	q := "/* test-test-5775b87c5d-fczwg|@test-test|test-test|internal|/internal/test|test-test */\n\n  SELECT /*+ MAX_EXECUTION_TIME(7995) */ `id`, `domain`, `city_id`, `name`, `polygon`, `state`, `translations` AS `translations`\n  FROM `area`\n  WHERE `state` IN ('active', 'disabled', 'removed') AND `domain` = 'test'"
+	
+	assert.Equal(
+		t,
+		"select `id`, `domain`, `city_id`, `name`, `polygon`, `state`, `translations` as `translations` from `area` where `state` in(?+) and `domain` = ?",
+		query.Fingerprint(q),
+	)
+}
+
+func TestFingerprintMaxExecTimeNoBackticks(t *testing.T) {
+	q := "/* test-test-5775b87c5d-fczwg|@test-test|test-test|internal|/internal/test|test-test */\n\n  SELECT /*+ MAX_EXECUTION_TIME(7995) */ id, domain, city_id, name, polygon, state, translations AS translations\n  FROM area\n  WHERE state IN ('active', 'disabled', 'removed') AND domain = 'test'"
+	
+	assert.Equal(t,
+		"select id, domain, city_id, name, polygon, state, translations as translations from area where state in(?+) and domain = ?",
+		query.Fingerprint(q),
+	)
+}


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PMM-13757

Function `func Fingerprint(q string) string` does not work correctly with `SELECT /*+ MAX_EXECUTION_TIME(<number>) */` statement.

For queries where column names are wrapped into backticks ``, `MAX_EXECUTION_TIME(123)` statement is preserved with a number. The number is not replaced by ?.

For queries where column names are **not** wrapped into backticks, it works correctly and does not copy `MAX_EXECUTION_TIME(<number>)` to a fingerprint at all.

This PR:

1. Adds tests for above-mentioned cases
2. Adds a fix that make the `Fingerprint()` function work correctly with `MAX_EXECUTION_TIME()`
